### PR TITLE
Fix placeholder text in search bar

### DIFF
--- a/dumi-theme/src/slots/Header/Search/index.tsx
+++ b/dumi-theme/src/slots/Header/Search/index.tsx
@@ -44,7 +44,7 @@ export const Search = () => {
           onFocus={() => setOpen(!!result?.length)}
           onChange={(e) => setKeywords(e.target.value)}
           placeholder={intl.formatMessage({
-            id: '搜索…',
+            id: 'Search...',
           })}
         />
       </label >


### PR DESCRIPTION
By default, it should be in English.